### PR TITLE
Bumping up version from 0.2.0 -> 0.2.1

### DIFF
--- a/pinliner/__init__.py
+++ b/pinliner/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 
 __author__ = 'Gorka Eguileor'
 __email__ = 'gorka@eguileor.com'
-__version__ = '0.2.0'
+__version__ = '0.2.1'


### PR DESCRIPTION
When python 3 support changes were done. This version wasn't upgraded. So when we install this module, python3 changes doesn't comes with `pip install pinliner`